### PR TITLE
docs: Remove QuickStart link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 
 ## Documentation
 
-- [QuickStart](https://auth0.com/docs/quickstart/webapp/fastapi)- our guide for adding Auth0 to your Fastapi app.
 - [Examples](https://github.com/auth0/auth0-fastapi-api/blob/main/EXAMPLES.md) - examples for your different use cases.
 - [Docs Site](https://auth0.com/docs) - explore our docs site and learn more about Auth0.
 


### PR DESCRIPTION
### Changes
Removed QuickStart link for Auth0 Fastapi app, as the link is incorrect. New quickstart will be updated soon.

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All existing and new tests complete without errors
