### PR TITLE
fix: use absolute artifact path for RL scanner

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,7 @@ jobs:
         uses: auth0/devsecops-tooling/.github/actions/rl-scan@main
         with:
           artifact-name: "auth0-fastapi-api"
-          artifact-path: "auth0-fastapi-api.tgz"
+          artifact-path: "${{ github.workspace }}/auth0-fastapi-api.tgz"
           version: ${{ steps.get_version.outputs.version }}
           RLSECURE_LICENSE: ${{ secrets.RLSECURE_LICENSE }}
           RLSECURE_SITE_KEY: ${{ secrets.RLSECURE_SITE_KEY }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,7 +59,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, 'release/'))
     name: "PyPI"
     runs-on: ubuntu-latest
-    # needs: rl-scanner
+    needs: rl-scanner
     environment: release
 
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,6 @@
 name: Publish Release
 
 on:
-  push:
-    branches:
-      - debug-rl-scanner  # TEMPORARY: remove after RL scanner debugging
   workflow_dispatch:
 
 ### TODO: Replace instances of './.github/actions/' with reference to the `dx-sdk-actions` repo is made public and this file is transferred over
@@ -15,7 +12,7 @@ permissions:
 
 jobs:
   rl-scanner:
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, 'release/'))
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, 'release/'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -59,8 +56,7 @@ jobs:
           PRODSEC_PYTHON_TOOLS_REPO: ${{ secrets.PRODSEC_PYTHON_TOOLS_REPO }}
 
   publish-pypi:
-    if: false # TEMPORARY: disabled during RL scanner debugging — original condition below
-    # if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, 'release/'))
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, 'release/'))
     name: "PyPI"
     runs-on: ubuntu-latest
     # needs: rl-scanner

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,9 @@
 name: Publish Release
 
 on:
+  push:
+    branches:
+      - debug-rl-scanner  # TEMPORARY: remove after RL scanner debugging
   workflow_dispatch:
 
 ### TODO: Replace instances of './.github/actions/' with reference to the `dx-sdk-actions` repo is made public and this file is transferred over
@@ -12,7 +15,7 @@ permissions:
 
 jobs:
   rl-scanner:
-    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, 'release/'))
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, 'release/'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -56,7 +59,8 @@ jobs:
           PRODSEC_PYTHON_TOOLS_REPO: ${{ secrets.PRODSEC_PYTHON_TOOLS_REPO }}
 
   publish-pypi:
-    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, 'release/'))
+    if: false # TEMPORARY: disabled during RL scanner debugging — original condition below
+    # if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, 'release/'))
     name: "PyPI"
     runs-on: ubuntu-latest
     # needs: rl-scanner


### PR DESCRIPTION
### Changes
- Use `github.workspace` for `artifact-path` in the RL scanner step to provide an absolute path to the build artifact